### PR TITLE
Close #38 Open Source Artifacts 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# Nipo Open Source Code of Conduct
+
+In this code of conduct are guidelines for the participation of Nipos's Open-Source-Project, and outlines the process for reporting unacceptable behavior. As an volunteer project, we are committed to providing an friendly environment for everyone. Anyone who break or violating this code of conduct may be removed and banned from the project.
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the project or its community in public spaces. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [mcflyhalf@live.com]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html and the Introduction section from the [template][template1] established by the [TODO Group][TODOGroup1].
+
+[homepage]: https://www.contributor-covenant.org
+[template1]: https://github.com/todogroup/opencodeofconduct/
+[TODOGroup1]: https://todogroup.org/
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,106 @@
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+
+      appropriateness of using or redistributing the Work and assume any
+
+      risks associated with Your exercise of permissions under this License.
+
+
+
+   8. Limitation of Liability. In no event and under no legal theory,
+
+      whether in tort (including negligence), contract, or otherwise,
+
+      unless required by applicable law (such as deliberate and grossly
+
+      negligent acts) or agreed to in writing, shall any Contributor be
+
+      liable to You for damages, including any direct, indirect, special,
+
+      incidental, or consequential damages of any character arising as a
+
+      result of this License or out of the use or inability to use the
+
+      Work (including but not limited to damages for loss of goodwill,
+
+      work stoppage, computer failure or malfunction, or any and all
+
+      other commercial damages or losses), even if such Contributor
+
+      has been advised of the possibility of such damages.
+
+
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+
+      the Work or Derivative Works thereof, You may choose to offer,
+
+      and charge a fee for, acceptance of support, warranty, indemnity,
+
+      or other liability obligations and/or rights consistent with this
+
+      License. However, in accepting such obligations, You may act only
+
+      on Your own behalf and on Your sole responsibility, not on behalf
+
+      of any other Contributor, and only if You agree to indemnify,
+
+      defend, and hold each Contributor harmless for any liability
+
+      incurred by, or claims asserted against, such Contributor by reason
+
+      of your accepting any such warranty or additional liability.
+
+
+
+   END OF TERMS AND CONDITIONS
+
+
+
+   APPENDIX: How to apply the Apache License to your work.
+
+
+
+      To apply the Apache License to your work, attach the following
+
+      boilerplate notice, with the fields enclosed by brackets "[]"
+
+      replaced with your own identifying information. (Don't include
+
+      the brackets!)  The text should be enclosed in the appropriate
+
+      comment syntax for the file format. We also recommend that a
+
+      file or class name and description of purpose be included on the
+
+      same "printed page" as the copyright notice for easier
+
+      identification within third-party archives.
+
+
+
+   Copyright [2021] [Josiah Nyangaga]
+
+
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+
+   you may not use this file except in compliance with the License.
+
+   You may obtain a copy of the License at
+
+
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+
+
+   Unless required by applicable law or agreed to in writing, software
+
+   distributed under the License is distributed on an "AS IS" BASIS,
+
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+   See the License for the specific language governing permissions and
+
+   limitations under the License.
+


### PR DESCRIPTION
In my opinion there are only two licenses for this project Apache and MIT. The reason why I think Apache is the right one is:  The Apache license says “do whatever you want with this, just don’t sue me” but does ist with many more words then MIT and lawyers like it, because it adds specificity. Apache also contains a patent license and retaliation clause which is designed to prevent patents from encumbering the software project. But it's up to you which one you think is best.