### PR TITLE
[BUGFIX] Fix issue occuring when performing multiple calls requiring …

### DIFF
--- a/nipo/conf.py
+++ b/nipo/conf.py
@@ -116,8 +116,8 @@ production_engine = create_engine('postgresql://{dbuser}:{passwd}@{host}:{port}/
 	port = os.environ['POSTGRES_PORT'],
 	dbname = os.environ['POSTGRES_NIPO_DBNAME']))
 
-Session = sessionmaker(bind=production_engine)
-production_session = Session()
+ProductionSession = sessionmaker(bind=production_engine)
+production_session = ProductionSession()
 
 test_engine = create_engine('postgresql://{dbuser}:{passwd}@{host}:{port}/{dbname}'.format(\
 	dbuser = os.environ['POSTGRES_USER'] ,
@@ -129,8 +129,10 @@ test_engine = create_engine('postgresql://{dbuser}:{passwd}@{host}:{port}/{dbnam
 
 TestSession = sessionmaker(bind=test_engine)
 test_session = TestSession()
-if os.environ['FLASK_ENV'] == 'production':		
+if os.environ['FLASK_ENV'] == 'production':
+	Session = ProductionSession	
 	session = production_session
 else:
-	session = test_session		 
+	Session = TestSession 
+	session = test_session
 

--- a/nipo/nipo_api.py
+++ b/nipo/nipo_api.py
@@ -33,6 +33,10 @@ UPLOAD_PATH = os.path.join(tempfile.gettempdir(), "nipo")
 def load_user(user_id):
     return session.query(schema.User).filter(schema.User.id==int(user_id)).one_or_none()
 
+@app.teardown_appcontext
+def shutdown_session(exception=None):
+    session.close()
+
 def make_form_dict():
 	form = {}
 	form['course'] = AddCourseForm()

--- a/nipo/static/samples/other_venue_upload.csv
+++ b/nipo/static/samples/other_venue_upload.csv
@@ -1,0 +1,3 @@
+Venue code,Venue name,Venue capacity
+EMB007,Engineering Main Building Rm 7,40
+H7001,Hall 7 Room 1,25

--- a/nipo/static/samples/packed_venue_upload.csv
+++ b/nipo/static/samples/packed_venue_upload.csv
@@ -1,5 +1,5 @@
 Venue code,Venue name,Venue capacity
-EMB006,Engineering Main Building Rm 6,100
+EMB006,Engineering Main Building Rm 7,100
 EMB008,Engineering Main Building Rm 8,101
 EMB009,Engineering Main Building Rm 9,102
 EMB010,Engineering Main Building Rm 10,103


### PR DESCRIPTION
…DB access

When accessing the DB, there was an issue that would cause an EOF exception to be emitted
by psycopg2 if the db was accessed multiple times in the same celery instance. This is caused
by the fact that SQLAlchemy sessions are designed to be used within a single process.
This fixes this by having each process keep its own instance of the SQLAlchemy session.